### PR TITLE
Add mingw target for Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ kotlin {
         fromPreset(presets.iosX64, 'iosX64')
         fromPreset(presets.iosArm32, 'iosArm32')
         fromPreset(presets.iosArm64, 'iosArm64')
+        fromPreset(presets.mingwX64, 'mingw')
     }
     sourceSets {
         commonMain {
@@ -108,7 +109,7 @@ kotlin {
             dependsOn appleTest
         }
 
-        /*otherNativeMain {
+        otherNativeMain {
             dependsOn nativeCommonMain
         }
 
@@ -116,7 +117,15 @@ kotlin {
             dependsOn nativeCommonTest
         }
 
-        configure([androidNativeArm32, androidNativeArm64]) {
+        configure([mingwMain]) {
+            dependsOn otherNativeMain
+        }
+
+        configure([mingwTest]) {
+            dependsOn otherNativeTest
+        }
+
+        /*configure([androidNativeArm32, androidNativeArm64]) {
             dependsOn otherNativeMain
         }
 

--- a/src/appleTest/kotlin/co/touchlab/stately/collections/MPWorker.kt
+++ b/src/appleTest/kotlin/co/touchlab/stately/collections/MPWorker.kt
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package co.touchlab.stately
+package co.touchlab.stately.collections
 
-import kotlin.random.Random
+import platform.Foundation.NSThread
 
-actual class Random actual constructor() {
-    actual fun nextInt(): Int = Random.nextInt()
+actual fun sleep(time: Long) {
+    NSThread.sleepForTimeInterval(time.toDouble()/1000.toDouble())
 }

--- a/src/mingwTest/kotlin/co/touchlab/stately/collections/MPWorker.kt
+++ b/src/mingwTest/kotlin/co/touchlab/stately/collections/MPWorker.kt
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package co.touchlab.stately
+package co.touchlab.stately.collections
 
-import kotlin.random.Random
+import platform.windows.Sleep
 
-actual class Random actual constructor() {
-    actual fun nextInt(): Int = Random.nextInt()
+@ExperimentalUnsignedTypes
+actual fun sleep(time: Long) {
+    Sleep(time.toUInt())
 }

--- a/src/nativeCommonTest/kotlin/co/touchlab/stately/collections/MPWorker.kt
+++ b/src/nativeCommonTest/kotlin/co/touchlab/stately/collections/MPWorker.kt
@@ -16,7 +16,6 @@
 
 package co.touchlab.stately.collections
 
-import platform.Foundation.NSThread
 import kotlin.native.concurrent.Future
 import kotlin.native.concurrent.TransferMode
 import kotlin.native.concurrent.Worker
@@ -38,10 +37,6 @@ actual class MPWorker actual constructor(){
 
 actual class MPFuture<T>(private val future:Future<T>) {
     actual fun consume():T = future.result
-}
-
-actual fun sleep(time: Long) {
-    NSThread.sleepForTimeInterval(time.toDouble()/1000.toDouble())
 }
 
 actual fun currentTimeMillis(): Long = getTimeMillis()

--- a/src/nativeCommonTest/kotlin/prototypes/makeListSizeOf.kt
+++ b/src/nativeCommonTest/kotlin/prototypes/makeListSizeOf.kt
@@ -20,7 +20,7 @@ import co.touchlab.stately.collections.ListData
 import co.touchlab.stately.collections.SharedLinkedList
 import co.touchlab.stately.collections.frozenCopyOnWriteList
 import co.touchlab.stately.collections.frozenLinkedList
-import platform.Foundation.NSLock
+import co.touchlab.stately.concurrency.Lock
 import kotlin.native.concurrent.*
 import kotlin.system.getTimeMillis
 
@@ -80,7 +80,7 @@ class SharedMutableList<E>():MutableList<E>{
         DetachedObjectGraph(mode = TransferMode.SAFE,
             producer = { mutableListOf<E>() as Any })
     )
-    private val lock = NSLock()
+    private val lock = Lock()
     internal fun withLockDetached(proc: (MutableList<E>) -> MutableList<E>) {
         lock.lock()
         try {

--- a/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/QuickLock.kt
+++ b/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/QuickLock.kt
@@ -2,15 +2,19 @@ package co.touchlab.stately.concurrency
 
 import kotlin.native.concurrent.AtomicInt
 
-actual class QuickLock actual constructor() : Lock {
+actual class Lock actual constructor() {
     val lock = AtomicInt(0)
 
-    actual override fun lock() {
+    actual fun lock() {
         spinLock()
     }
 
-    actual override fun unlock() {
+    actual fun unlock() {
         spinUnlock()
+    }
+
+    actual fun tryLock():Boolean {
+        return lock.compareAndSet(0, 1)
     }
 
     private fun spinLock(){


### PR DESCRIPTION
Adds a `mingw` target to allow building on Windows.

For now, this uses the spinlock in `QuickLock.kt`. Future work includes using Windows synchronization primitives, though there currently isn't a great story for tying the lifetime of such native objects to the `Lock`.

Also includes some test refactoring to move `actual fun sleep` out to each platform and to use the multiplatform `kotlin.random.Random` instead of `platform.posix.arc4random`.