### PR TITLE
Make the native lock re-entrant

### DIFF
--- a/stately/src/commonMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
+++ b/stately/src/commonMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
@@ -17,7 +17,8 @@
 package co.touchlab.stately.concurrency
 
 /**
- * A simple mutex lock.
+ * A simple lock.
+ * Implementations of this class should be re-entrant.
  */
 expect class Lock() {
   fun lock()

--- a/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
+++ b/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
@@ -1,9 +1,21 @@
 package co.touchlab.stately.concurrency
 
+import co.touchlab.stately.freeze
 import kotlin.native.concurrent.AtomicInt
+import kotlin.native.concurrent.ThreadLocal
 
+@ThreadLocal
+private object Thread {
+  val id = Any().freeze().hashCode()
+}
+
+/*
+ * This is a re-entrant implementation of Lock.
+ * a thread may acquire the lock as many times as the wish.
+ */
 actual class Lock actual constructor() {
-  val lock = AtomicInt(0)
+  private val lock = AtomicInt(0)
+  private val reenterCount = AtomicInt(0)
 
   actual fun lock() {
     spinLock()
@@ -14,15 +26,33 @@ actual class Lock actual constructor() {
   }
 
   actual fun tryLock():Boolean {
-    return lock.compareAndSet(0, 1)
+    return when (lock.compareAndSwap(0, Thread.id)) {
+      Thread.id -> {
+        // We already have the lock, we are just re-entering.
+        reenterCount.increment()
+        true
+      }
+      0 -> {
+        // Another thread didn't have the lock so we just took it.
+        assert(reenterCount.value == 0)
+        true
+      }
+      else -> false
+    }
   }
 
-  private fun spinLock(){
-    while (!lock.compareAndSet(0, 1)){}
+  private fun spinLock() {
+    while (!tryLock()) {}
   }
 
   private fun spinUnlock(){
-    if(!lock.compareAndSet(1, 0))
-      throw IllegalStateException("Lock must always be 1 in unlock")
+    // Because this is re-entrant we should only unlock if the count is 0.
+    if (reenterCount.value > 0) {
+      reenterCount.decrement()
+    } else {
+      val currentThread = Thread.id
+      val lastThread = lock.compareAndSwap(currentThread, 0)
+      assert(currentThread == lastThread)
+    }
   }
 }

--- a/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
+++ b/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
@@ -5,7 +5,8 @@ import kotlin.native.concurrent.ThreadLocal
 
 @ThreadLocal
 private object Thread {
-  val id: Int by lazy { Any().hashCode() }
+  private val pointer: Any by lazy { Any() }
+  val id: Int by lazy { pointer.hashCode() }
 }
 
 /*

--- a/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
+++ b/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
@@ -46,7 +46,7 @@ actual class Lock actual constructor() {
   }
 
   private fun spinUnlock(){
-    assert(lock.value != Thread.id)
+    assert(lock.value == Thread.id)
     
     // Because this is re-entrant we should only unlock if the count is 0.
     if (reenterCount.value > 0) {

--- a/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
+++ b/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
@@ -1,6 +1,5 @@
 package co.touchlab.stately.concurrency
 
-import co.touchlab.stately.freeze
 import kotlin.native.concurrent.AtomicInt
 import kotlin.native.concurrent.ThreadLocal
 
@@ -11,7 +10,7 @@ private object Thread {
 
 /*
  * This is a re-entrant implementation of Lock.
- * a thread may acquire the lock as many times as the wish.
+ * a thread may acquire the lock as many times as they wish.
  */
 actual class Lock actual constructor() {
   private val lockedThreadId = AtomicInt(0)

--- a/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
+++ b/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
@@ -33,7 +33,7 @@ actual class Lock actual constructor() {
       }
       0 -> {
         // Another thread didn't have the lock so we just took it.
-        assert(reenterCount.value == 0) { "Another thread just took a lock that had a non-zero reenter count." }
+        assert(reenterCount.value == 0) { "Attempt to acquire a lock with a non-zero reenter count." }
         true
       }
       else -> false
@@ -45,7 +45,7 @@ actual class Lock actual constructor() {
   }
 
   private fun spinUnlock(){
-    assert(lockedThreadId.value == Thread.id) { "Attempting to unlock from a thread that doesn't have the lock." }
+    assert(lockedThreadId.value == Thread.id) { "Attempt to unlock from a thread that doesn't own the lock." }
 
     // Because this is re-entrant we should only unlock if the count is 0.
     if (reenterCount.value > 0) {

--- a/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
+++ b/stately/src/otherNativeMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
@@ -6,7 +6,7 @@ import kotlin.native.concurrent.ThreadLocal
 
 @ThreadLocal
 private object Thread {
-  val id = Any().freeze().hashCode()
+  val id: Int by lazy { Any().hashCode() }
 }
 
 /*
@@ -46,13 +46,14 @@ actual class Lock actual constructor() {
   }
 
   private fun spinUnlock(){
+    assert(lock.value != Thread.id)
+    
     // Because this is re-entrant we should only unlock if the count is 0.
     if (reenterCount.value > 0) {
       reenterCount.decrement()
     } else {
       val currentThread = Thread.id
-      val lastThread = lock.compareAndSwap(currentThread, 0)
-      assert(currentThread == lastThread)
+      lock.compareAndSet(currentThread, 0)
     }
   }
 }


### PR DESCRIPTION
The current implementation of the lock on iOS uses NSRecursiveLock, where as anything using otherNativeMain source sets (mingw), is just using a spin lock. This was causing some issues for me when working with other libraries that were expecting locks to be re-entrant. 

This will make the lock in otherNativeMain more consistent with the apple implementation.