### PR TITLE
Fix windows build

### DIFF
--- a/stately/build.gradle
+++ b/stately/build.gradle
@@ -112,6 +112,10 @@ kotlin {
             dependsOn nativeCommonMain
         }
 
+        mingwMain {
+            dependsOn nativeCommonMain
+        }
+
         configure([targets.iosX64,
                    targets.iosArm32,
                    targets.iosArm64,
@@ -120,8 +124,7 @@ kotlin {
             compilations.test.source(sourceSets.nativeCommonTest)
         }
 
-        configure([targets.mingwX64,
-                   targets.linuxX64,
+        configure([targets.linuxX64,
                    targets.linuxArm32Hfp,
                    targets.linuxMips32
 //                   ,
@@ -129,6 +132,11 @@ kotlin {
 //                   targets.androidNativeArm64
         ]) {
             compilations.main.source(sourceSets.pthreadMain)
+            compilations.test.source(sourceSets.nativeCommonTest)
+        }
+
+        configure([targets.mingwX64]) {
+            compilations.main.source(sourceSets.mingwMain)
             compilations.test.source(sourceSets.nativeCommonTest)
         }
     }

--- a/stately/src/mingwMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
+++ b/stately/src/mingwMain/kotlin/co/touchlab/stately/concurrency/Lock.kt
@@ -1,0 +1,54 @@
+package co.touchlab.stately.concurrency
+
+import kotlinx.cinterop.Arena
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.ptr
+import platform.posix.PTHREAD_MUTEX_RECURSIVE
+import platform.posix.pthread_mutex_destroy
+import platform.posix.pthread_mutex_init
+import platform.posix.pthread_mutex_lock
+import platform.posix.pthread_mutex_tVar
+import platform.posix.pthread_mutex_trylock
+import platform.posix.pthread_mutex_unlock
+import platform.posix.pthread_mutexattr_destroy
+import platform.posix.pthread_mutexattr_init
+import platform.posix.pthread_mutexattr_settype
+import platform.posix.pthread_mutexattr_tVar
+import kotlin.native.concurrent.freeze
+
+/**
+ * A simple lock.
+ * Implementations of this class should be re-entrant.
+ */
+actual class Lock actual constructor() {
+    private val arena = Arena()
+    private val attr = arena.alloc<pthread_mutexattr_tVar>()
+    private val mutex = arena.alloc<pthread_mutex_tVar>()
+
+    init {
+        pthread_mutexattr_init(attr.ptr)
+        pthread_mutexattr_settype(attr.ptr, PTHREAD_MUTEX_RECURSIVE.toInt())
+        pthread_mutex_init(mutex.ptr, attr.ptr)
+        freeze()
+    }
+
+    actual fun lock() {
+        pthread_mutex_lock(mutex.ptr)
+    }
+
+    actual fun unlock() {
+        pthread_mutex_unlock(mutex.ptr)
+    }
+
+    actual fun tryLock(): Boolean = pthread_mutex_trylock(mutex.ptr) == 0
+
+    fun internalClose(){
+        pthread_mutex_destroy(mutex.ptr)
+        pthread_mutexattr_destroy(attr.ptr)
+        arena.clear()
+    }
+}
+
+actual inline fun Lock.close() {
+    internalClose()
+}


### PR DESCRIPTION
The changes here are not as significant as they look. 

Apparently on windows the Area.alloc implementation is a bit different and it wants the types provided to be CVariables. The types I had to use on windows are not available on linux.

So these two lines: 
```
private val attr = arena.alloc<pthread_mutexattr_t>()
private val mutex = arena.alloc<pthread_mutex_t>()
```
are change to:
```
private val attr = arena.alloc<pthread_mutexattr_tVar>()
private val mutex = arena.alloc<pthread_mutex_tVar>()
```
in the wingw folder.

Build and tests are both successful on windows with this change.