### PR TITLE
Remove superfluous value reads after write

### DIFF
--- a/stately-concurrency/src/jsWasmMain/kotlin/co/touchlab/stately/concurrency/AtomicInt.kt
+++ b/stately-concurrency/src/jsWasmMain/kotlin/co/touchlab/stately/concurrency/AtomicInt.kt
@@ -23,8 +23,9 @@ actual class AtomicInt actual constructor(initialValue: Int) {
     private var internalValue: Int = initialValue
 
     actual fun addAndGet(delta: Int): Int {
-        internalValue += delta
-        return internalValue
+        return (internalValue + delta).also {
+            internalValue = it
+        }
     }
 
     actual fun compareAndSet(expected: Int, new: Int): Boolean {

--- a/stately-concurrency/src/jsWasmMain/kotlin/co/touchlab/stately/concurrency/AtomicLong.kt
+++ b/stately-concurrency/src/jsWasmMain/kotlin/co/touchlab/stately/concurrency/AtomicLong.kt
@@ -23,8 +23,9 @@ actual class AtomicLong actual constructor(initialValue: Long) {
     private var internalValue: Long = initialValue
 
     actual fun addAndGet(delta: Long): Long {
-        internalValue += delta
-        return internalValue
+        return (internalValue + delta).also {
+            internalValue = it
+        }
     }
 
     actual fun compareAndSet(expected: Long, new: Long): Boolean {


### PR DESCRIPTION
The new value is already available locally and can be returned directly.