### PR TITLE
Close native locks with Synchronizable

### DIFF
--- a/stately-concurrency/src/nativeMain/kotlin/co/touchlab/stately/concurrency/Functions.kt
+++ b/stately-concurrency/src/nativeMain/kotlin/co/touchlab/stately/concurrency/Functions.kt
@@ -2,10 +2,23 @@
 
 package co.touchlab.stately.concurrency
 
-actual open class Synchronizable(private val _lock: Lock) {
-    actual constructor() : this(Lock())
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ref.createCleaner
 
-    fun <R> runSynchronized(block: () -> R): R = _lock.withLock(block)
+actual open class Synchronizable internal constructor(private val resource: SynchronizationResource) {
+    actual constructor() : this(SynchronizationResource())
+
+    @Suppress("unused")
+    @OptIn(ExperimentalNativeApi::class)
+    private val cleaner = createCleaner(resource, SynchronizationResource::close)
+
+    fun <R> runSynchronized(block: () -> R): R = resource.lock.withLock(block)
+}
+
+internal open class SynchronizationResource(internal val lock: Lock = Lock()) {
+    internal open fun close() {
+        lock.close()
+    }
 }
 
 actual inline fun <R> Synchronizable.synchronize(noinline block: () -> R): R = runSynchronized(block)

--- a/stately-concurrency/src/nativeTest/kotlin/co/touchlab/stately/concurrency/SynchronizableTest.kt
+++ b/stately-concurrency/src/nativeTest/kotlin/co/touchlab/stately/concurrency/SynchronizableTest.kt
@@ -1,0 +1,37 @@
+package co.touchlab.stately.concurrency
+
+import kotlin.native.runtime.GC
+import kotlin.native.runtime.NativeRuntimeApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(NativeRuntimeApi::class)
+class SynchronizableTest {
+    @Test
+    fun closesLockWhenCollected() {
+        val closeCount = AtomicInt(0)
+        val resource = object : SynchronizationResource() {
+            override fun close() {
+                super.close()
+                closeCount.incrementAndGet()
+            }
+        }
+
+        useResource(resource)
+
+        repeat(100) {
+            GC.collect()
+            if (closeCount.get() == 1) {
+                GC.collect()
+                assertEquals(1, closeCount.get())
+                return
+            }
+        }
+
+        assertEquals(1, closeCount.get())
+    }
+
+    private fun useResource(resource: SynchronizationResource) {
+        Synchronizable(resource).synchronize {}
+    }
+}


### PR DESCRIPTION
Owns the native `Lock` in a cleaner-backed resource so `Synchronizable` closes it when it becomes unreachable. Adds a native GC regression test that verifies cleanup happens exactly once.

Tests: native and JVM suites, ktlint, and API validation.

Closes #117.
